### PR TITLE
Update install-cursor.sh to show Dash icon on Gnome

### DIFF
--- a/install-cursor.sh
+++ b/install-cursor.sh
@@ -88,6 +88,7 @@ cat > "$DESKTOP_ENTRY_PATH" <<EOL
 Name=Cursor (Patched)
 Comment=The AI-first Code Editor
 Icon=$ICON_NAME
+StartupWMClass=Cursor
 Exec=$EXECUTABLE_SYMLINK
 Type=Application
 Categories=Development;IDE;


### PR DESCRIPTION
This is in order to get a nice icon in Gnome dashboard:
![image](https://github.com/user-attachments/assets/a6a583e1-0f04-4107-9d3b-f0d42a09e9e3)

Based on this:
https://itsfoss.com/ubuntu-app-icon-missing/