### PR TITLE
Fix Cursor API URL (remove "www.")

### DIFF
--- a/install-cursor.sh
+++ b/install-cursor.sh
@@ -31,7 +31,7 @@ echo "--> Dependencies are satisfied."
 # --- Installation ---
 
 echo "--> Fetching the latest Cursor AppImage download link..."
-LATEST_URL=$(curl -s 'https://www.cursor.com/api/download?platform=linux-x64&releaseTrack=latest' | jq -r '.downloadUrl')
+LATEST_URL=$(curl -s 'https://cursor.com/api/download?platform=linux-x64&releaseTrack=latest' | jq -r '.downloadUrl')
 
 if [ -z "$LATEST_URL" ] || [ "$LATEST_URL" == "null" ]; then
     echo "Error: Failed to retrieve the download URL. Aborting."


### PR DESCRIPTION
Fixes #2 

```
$ echo $(curl -s 'https://www.cursor.com/api/download?platform=linux-x64&releaseTrack=latest' | jq -r '.downloadUrl')
jq: parse error: Invalid numeric literal at line 2, column 0

$ echo $(curl -s 'https://cursor.com/api/download?platform=linux-x64&releaseTrack=latest' | jq -r '.downloadUrl') 
https://downloads.cursor.com/production/031e7e0ff1e2eda9c1a0f5df67d44053b059c5df/linux/x64/Cursor-1.2.1-x86_64.AppImage
```